### PR TITLE
Add comprehensive self-testing environment for Hachiko migrations

### DIFF
--- a/.hachiko.yml
+++ b/.hachiko.yml
@@ -1,0 +1,52 @@
+plans:
+  directory: migrations/
+  filenamePattern: "*.md"
+
+defaults:
+  agent: claude-cli
+  prParallelism: 1
+  rebase:
+    when: behind-base-branch
+    allowManual: true
+  labels: [hachiko, migration]
+  requirePlanReview: true
+
+aiConfigs:
+  provider: launchdarkly
+  flagKeyPrefix: hachiko_prompts_
+
+policy:
+  allowWorkflowEdits: false
+  network: none
+  maxAttemptsPerStep: 2
+  stepTimeoutMinutes: 15
+  perRepoMaxConcurrentMigrations: 3
+  riskyGlobs:
+    - ".github/workflows/**"
+    - ".git/**"
+    - "**/*.sh"
+  allowlistGlobs:
+    - "src/**"
+    - "self-test/**"
+    - "examples/fixtures/**"
+    - "test/**"
+    - "**/*.test.tsx"
+    - "**/*.test.ts"
+
+dependencies:
+  conflictResolution: fail
+  updateStrategy: manual
+
+agents:
+  claude-cli:
+    kind: cli
+    command: claude
+    args: ["code", "--apply"]
+  cursor-cli:
+    kind: cli
+    command: cursor
+    args: ["--headless", "apply"]
+  mock-agent:
+    kind: cli
+    command: echo
+    args: ["Mock agent executed successfully"]

--- a/migrations/self-test-react-hooks.md
+++ b/migrations/self-test-react-hooks.md
@@ -1,0 +1,170 @@
+---
+id: self-test-react-hooks
+title: "Self-Test: Convert React Class Components to Hooks"
+owner: "@hachiko-team"
+status: draft
+agent: claude-cli
+strategy:
+  chunkBy: file
+  maxOpenPRs: 1
+checks:
+  - "npm run test"
+  - "npm run type-check"
+  - "npm run lint"
+rollback:
+  - description: "Revert if tests fail or type errors introduced"
+    command: "git revert HEAD"
+successCriteria:
+  - "All class components in self-test/ converted to hooks"
+  - "All tests pass"
+  - "No TypeScript errors"
+  - "ESLint rules pass"
+steps:
+  - id: simple-components
+    description: "Convert simple components like UserCard with basic state and event handlers"
+    expectedPR: true
+  - id: lifecycle-components  
+    description: "Convert DataFetcher component with componentDidMount, componentDidUpdate, and cleanup"
+    expectedPR: true
+  - id: complex-components
+    description: "Convert FormWizard with refs, getDerivedStateFromProps, advanced lifecycle methods, and complex state"
+    expectedPR: true
+dependsOn: []
+touches:
+  - "self-test/src/components/**/*.tsx"
+  - "self-test/src/components/**/*.ts"
+---
+
+# Self-Test React Class to Hooks Migration
+
+This migration converts the class components in the `self-test/` directory to functional components using React hooks. This serves as an end-to-end test of Hachiko's migration capabilities.
+
+## Context
+
+The `self-test/` directory contains three React class components of increasing complexity:
+
+1. **UserCard** - Simple component with basic state (`isHovered`, `isLoading`)
+2. **DataFetcher** - Component with lifecycle methods (`componentDidMount`, `componentDidUpdate`, `componentWillUnmount`)
+3. **FormWizard** - Complex component with refs, `getDerivedStateFromProps`, advanced state management, and cleanup
+
+This migration tests Hachiko's ability to handle the full spectrum of React class component patterns.
+
+## Migration Strategy
+
+### Step 1: Simple Components (UserCard)
+- Convert basic state to `useState`
+- Transform event handlers to arrow functions
+- Maintain existing prop interfaces
+- Test hover state functionality
+
+**Before:**
+```typescript
+class UserCard extends React.Component<UserCardProps, UserCardState> {
+  constructor(props: UserCardProps) {
+    super(props)
+    this.state = {
+      isHovered: false,
+      isLoading: false,
+    }
+  }
+
+  handleMouseEnter = () => {
+    this.setState({ isHovered: true })
+  }
+```
+
+**After:**
+```typescript
+const UserCard: React.FC<UserCardProps> = ({ user, onClick, showAvatar = true }) => {
+  const [isHovered, setIsHovered] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleMouseEnter = () => {
+    setIsHovered(true)
+  }
+```
+
+### Step 2: Lifecycle Components (DataFetcher)
+- Convert `componentDidMount` to `useEffect(() => {}, [])`
+- Convert `componentDidUpdate` to `useEffect(() => {}, [dependencies])`
+- Convert `componentWillUnmount` cleanup to `useEffect` return function
+- Handle AbortController cleanup properly
+
+**Before:**
+```typescript
+componentDidMount() {
+  this.fetchData()
+}
+
+componentDidUpdate(prevProps: DataFetcherProps) {
+  if (prevProps.url !== this.props.url) {
+    this.fetchData()
+  }
+}
+
+componentWillUnmount() {
+  if (this.abortController) {
+    this.abortController.abort()
+  }
+}
+```
+
+**After:**
+```typescript
+useEffect(() => {
+  fetchData()
+}, [])
+
+useEffect(() => {
+  fetchData()
+}, [url])
+
+useEffect(() => {
+  return () => {
+    if (abortController) {
+      abortController.abort()
+    }
+  }
+}, [])
+```
+
+### Step 3: Complex Components (FormWizard)
+- Convert refs using `useRef`
+- Replace `getDerivedStateFromProps` with `useEffect` and state derivation
+- Handle complex state with multiple `useState` calls or `useReducer`
+- Convert lifecycle methods to appropriate `useEffect` hooks
+- Maintain event listener cleanup and auto-save functionality
+
+**Complex Patterns to Handle:**
+- Multiple refs stored in object → `useRef` for each
+- `getDerivedStateFromProps` → `useEffect` with dependency on props
+- Complex state updates → Consider `useReducer`
+- Event listeners on window → `useEffect` with cleanup
+- setTimeout/setInterval → `useEffect` with cleanup
+
+## Success Criteria
+
+1. All components are functional components using hooks
+2. No class component syntax remains
+3. All existing functionality is preserved
+4. TypeScript compilation passes
+5. All tests pass (when implemented)
+6. No ESLint errors related to hooks rules
+
+## Testing Notes
+
+This migration serves as a comprehensive test of Hachiko's capabilities:
+- **Step 1** tests basic state conversion
+- **Step 2** tests lifecycle method conversion  
+- **Step 3** tests complex patterns and edge cases
+
+The components are intentionally designed with realistic complexity patterns found in production React codebases.
+
+## Rollback Plan
+
+If any step fails:
+1. Revert the specific problematic commit
+2. Address issues in development
+3. Re-run migration step once fixes are validated
+
+This ensures the self-test environment remains stable while validating Hachiko's migration capabilities.

--- a/migrations/unoptimized-test-plan.md
+++ b/migrations/unoptimized-test-plan.md
@@ -1,0 +1,54 @@
+---
+id: unoptimized-test-plan
+title: "Unoptimized Test Migration Plan"
+owner: "@test-team"
+status: draft
+agent: claude-cli
+strategy:
+  chunkBy: module
+  maxOpenPRs: 5
+checks:
+  - "npm test"
+  - "npm run type-check"
+successCriteria:
+  - "Some basic criteria"
+  - "Test completion"
+steps:
+  - id: step1
+    description: "Do some basic transformation"
+    expectedPR: true
+  - id: step2  
+    description: "Continue with more changes"
+    expectedPR: true
+dependsOn: []
+touches:
+  - "self-test/**/*.tsx"
+---
+
+# Basic Test Migration
+
+This is an intentionally unoptimized migration plan that Hachiko should optimize when it's first checked in.
+
+## Issues that should be optimized:
+
+1. **Missing rollback plan** - No rollback strategy defined
+2. **Vague success criteria** - Not specific enough
+3. **Generic step descriptions** - Steps are too vague
+4. **Missing detailed strategy** - No clear migration approach
+5. **Incomplete checks** - Missing lint check
+6. **No risk assessment** - No complexity analysis
+7. **Minimal documentation** - Lacks implementation details
+8. **No dependency analysis** - Missing file dependency mapping
+
+## Expected Optimizations:
+
+Hachiko should detect these issues and:
+- Add specific rollback commands
+- Enhance success criteria with measurable outcomes  
+- Provide detailed step descriptions
+- Add comprehensive checks including linting
+- Include risk assessment and complexity analysis
+- Expand documentation with examples
+- Add proper dependency analysis
+
+This tests Hachiko's ability to improve migration plans automatically during the initial plan review process.

--- a/self-test/package.json
+++ b/self-test/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "hachiko-self-test",
+  "version": "1.0.0",
+  "description": "Self-testing environment for Hachiko migrations",
+  "scripts": {
+    "test": "echo 'Test placeholder'",
+    "type-check": "echo 'TypeScript check placeholder'",
+    "lint": "echo 'Lint check placeholder'"
+  },
+  "dependencies": {
+    "react": "^18.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/self-test/src/components/DataFetcher.tsx
+++ b/self-test/src/components/DataFetcher.tsx
@@ -1,0 +1,107 @@
+import React from "react"
+
+interface DataFetcherProps {
+  url: string
+  onDataLoaded?: (data: any) => void
+  onError?: (error: Error) => void
+  children: (data: any, loading: boolean, error: Error | null) => React.ReactNode
+}
+
+interface DataFetcherState {
+  data: any
+  loading: boolean
+  error: Error | null
+}
+
+/**
+ * Data fetcher component with lifecycle methods and complex state.
+ * This represents step 2: component with componentDidMount, componentDidUpdate, and error boundaries.
+ * More complex conversion requiring useEffect and proper dependency management.
+ */
+class DataFetcher extends React.Component<DataFetcherProps, DataFetcherState> {
+  private abortController: AbortController | null = null
+
+  constructor(props: DataFetcherProps) {
+    super(props)
+    this.state = {
+      data: null,
+      loading: false,
+      error: null,
+    }
+  }
+
+  componentDidMount() {
+    this.fetchData()
+  }
+
+  componentDidUpdate(prevProps: DataFetcherProps) {
+    if (prevProps.url !== this.props.url) {
+      this.fetchData()
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.abortController) {
+      this.abortController.abort()
+    }
+  }
+
+  fetchData = async () => {
+    // Cancel previous request
+    if (this.abortController) {
+      this.abortController.abort()
+    }
+
+    this.abortController = new AbortController()
+
+    this.setState({ loading: true, error: null })
+
+    try {
+      const response = await fetch(this.props.url, {
+        signal: this.abortController.signal,
+      })
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
+      }
+
+      const data = await response.json()
+
+      this.setState({ data, loading: false })
+
+      if (this.props.onDataLoaded) {
+        this.props.onDataLoaded(data)
+      }
+    } catch (error) {
+      if (error.name !== "AbortError") {
+        const errorObj = error instanceof Error ? error : new Error(String(error))
+        this.setState({ error: errorObj, loading: false })
+
+        if (this.props.onError) {
+          this.props.onError(errorObj)
+        }
+      }
+    }
+  }
+
+  retry = () => {
+    this.fetchData()
+  }
+
+  render() {
+    const { data, loading, error } = this.state
+
+    return (
+      <div className="data-fetcher">
+        {this.props.children(data, loading, error)}
+        {error && (
+          <button onClick={this.retry} className="retry-button">
+            Retry
+          </button>
+        )}
+      </div>
+    )
+  }
+}
+
+export default DataFetcher

--- a/self-test/src/components/DataFetcher.tsx
+++ b/self-test/src/components/DataFetcher.tsx
@@ -95,7 +95,7 @@ class DataFetcher extends React.Component<DataFetcherProps, DataFetcherState> {
       <div className="data-fetcher">
         {this.props.children(data, loading, error)}
         {error && (
-          <button onClick={this.retry} className="retry-button">
+          <button type="button" onClick={this.retry} className="retry-button">
             Retry
           </button>
         )}

--- a/self-test/src/components/FormWizard.tsx
+++ b/self-test/src/components/FormWizard.tsx
@@ -1,0 +1,288 @@
+import React from "react"
+
+interface Step {
+  id: string
+  title: string
+  component: React.ComponentType<any>
+  validate?: (data: any) => string | null
+}
+
+interface FormWizardProps {
+  steps: Step[]
+  onComplete: (data: any) => void
+  onStepChange?: (stepIndex: number) => void
+  initialData?: any
+}
+
+interface FormWizardState {
+  currentStepIndex: number
+  formData: any
+  errors: Record<string, string>
+  isSubmitting: boolean
+  history: number[]
+  hasUnsavedChanges: boolean
+}
+
+/**
+ * Complex form wizard with refs, advanced lifecycle methods, and intricate state management.
+ * This represents step 3: most complex conversion with refs, complex state updates,
+ * advanced patterns like getDerivedStateFromProps, and error boundaries.
+ */
+class FormWizard extends React.Component<FormWizardProps, FormWizardState> {
+  private formRefs: Record<string, React.RefObject<any>> = {}
+  private saveTimeoutId: NodeJS.Timeout | null = null
+
+  constructor(props: FormWizardProps) {
+    super(props)
+
+    // Initialize refs for each step
+    props.steps.forEach((step) => {
+      this.formRefs[step.id] = React.createRef()
+    })
+
+    this.state = {
+      currentStepIndex: 0,
+      formData: props.initialData || {},
+      errors: {},
+      isSubmitting: false,
+      history: [0],
+      hasUnsavedChanges: false,
+    }
+  }
+
+  static getDerivedStateFromProps(props: FormWizardProps, state: FormWizardState) {
+    // Update form data if initialData changes
+    if (props.initialData && Object.keys(state.formData).length === 0) {
+      return {
+        formData: { ...props.initialData },
+      }
+    }
+    return null
+  }
+
+  componentDidMount() {
+    // Focus first input when component mounts
+    this.focusCurrentStep()
+
+    // Set up auto-save
+    this.setupAutoSave()
+
+    // Add beforeunload listener for unsaved changes
+    window.addEventListener("beforeunload", this.handleBeforeUnload)
+  }
+
+  componentDidUpdate(prevProps: FormWizardProps, prevState: FormWizardState) {
+    if (prevState.currentStepIndex !== this.state.currentStepIndex) {
+      this.focusCurrentStep()
+
+      if (this.props.onStepChange) {
+        this.props.onStepChange(this.state.currentStepIndex)
+      }
+    }
+
+    if (prevState.formData !== this.state.formData) {
+      this.setState({ hasUnsavedChanges: true })
+      this.scheduleAutoSave()
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.saveTimeoutId) {
+      clearTimeout(this.saveTimeoutId)
+    }
+
+    window.removeEventListener("beforeunload", this.handleBeforeUnload)
+  }
+
+  handleBeforeUnload = (event: BeforeUnloadEvent) => {
+    if (this.state.hasUnsavedChanges) {
+      event.preventDefault()
+      event.returnValue = "You have unsaved changes. Are you sure you want to leave?"
+    }
+  }
+
+  focusCurrentStep = () => {
+    const currentStep = this.props.steps[this.state.currentStepIndex]
+    const stepRef = this.formRefs[currentStep.id]
+
+    if (stepRef.current && stepRef.current.focus) {
+      setTimeout(() => stepRef.current.focus(), 100)
+    }
+  }
+
+  setupAutoSave = () => {
+    // Save form data to localStorage every 30 seconds
+    const autoSaveInterval = setInterval(() => {
+      if (this.state.hasUnsavedChanges) {
+        localStorage.setItem("formWizard_autosave", JSON.stringify(this.state.formData))
+      }
+    }, 30000)
+
+    return () => clearInterval(autoSaveInterval)
+  }
+
+  scheduleAutoSave = () => {
+    if (this.saveTimeoutId) {
+      clearTimeout(this.saveTimeoutId)
+    }
+
+    this.saveTimeoutId = setTimeout(() => {
+      localStorage.setItem("formWizard_autosave", JSON.stringify(this.state.formData))
+      this.setState({ hasUnsavedChanges: false })
+    }, 2000)
+  }
+
+  validateCurrentStep = (): boolean => {
+    const currentStep = this.props.steps[this.state.currentStepIndex]
+
+    if (currentStep.validate) {
+      const error = currentStep.validate(this.state.formData)
+
+      if (error) {
+        this.setState({
+          errors: { ...this.state.errors, [currentStep.id]: error },
+        })
+        return false
+      } else {
+        const newErrors = { ...this.state.errors }
+        delete newErrors[currentStep.id]
+        this.setState({ errors: newErrors })
+      }
+    }
+
+    return true
+  }
+
+  goToNextStep = () => {
+    if (!this.validateCurrentStep()) return
+
+    const nextIndex = this.state.currentStepIndex + 1
+    if (nextIndex < this.props.steps.length) {
+      this.setState({
+        currentStepIndex: nextIndex,
+        history: [...this.state.history, nextIndex],
+      })
+    }
+  }
+
+  goToPreviousStep = () => {
+    const newHistory = [...this.state.history]
+    newHistory.pop() // Remove current step
+    const previousIndex = newHistory[newHistory.length - 1] || 0
+
+    this.setState({
+      currentStepIndex: previousIndex,
+      history: newHistory,
+    })
+  }
+
+  goToStep = (stepIndex: number) => {
+    if (stepIndex >= 0 && stepIndex < this.props.steps.length) {
+      this.setState({
+        currentStepIndex: stepIndex,
+        history: [...this.state.history, stepIndex],
+      })
+    }
+  }
+
+  updateFormData = (data: Partial<any>) => {
+    this.setState({
+      formData: { ...this.state.formData, ...data },
+    })
+  }
+
+  handleSubmit = async () => {
+    if (!this.validateCurrentStep()) return
+
+    this.setState({ isSubmitting: true })
+
+    try {
+      await this.props.onComplete(this.state.formData)
+
+      // Clear autosave data on successful submission
+      localStorage.removeItem("formWizard_autosave")
+      this.setState({ hasUnsavedChanges: false })
+    } catch (error) {
+      console.error("Form submission failed:", error)
+
+      this.setState({
+        errors: {
+          ...this.state.errors,
+          submit: error instanceof Error ? error.message : "Submission failed",
+        },
+      })
+    } finally {
+      this.setState({ isSubmitting: false })
+    }
+  }
+
+  render() {
+    const { steps } = this.props
+    const { currentStepIndex, formData, errors, isSubmitting, history } = this.state
+    const currentStep = steps[currentStepIndex]
+    const CurrentStepComponent = currentStep.component
+
+    const canGoBack = history.length > 1
+    const canGoNext = currentStepIndex < steps.length - 1
+    const isLastStep = currentStepIndex === steps.length - 1
+
+    return (
+      <div className="form-wizard">
+        <div className="wizard-header">
+          <div className="step-indicator">
+            {steps.map((step, index) => (
+              <div
+                key={step.id}
+                className={`step ${index === currentStepIndex ? "active" : ""} ${
+                  index < currentStepIndex ? "completed" : ""
+                }`}
+                onClick={() => this.goToStep(index)}
+              >
+                {step.title}
+              </div>
+            ))}
+          </div>
+
+          {this.state.hasUnsavedChanges && <div className="unsaved-indicator">Unsaved changes</div>}
+        </div>
+
+        <div className="wizard-content">
+          <h2>{currentStep.title}</h2>
+
+          {errors[currentStep.id] && <div className="error-message">{errors[currentStep.id]}</div>}
+
+          <CurrentStepComponent
+            ref={this.formRefs[currentStep.id]}
+            data={formData}
+            onChange={this.updateFormData}
+            errors={errors}
+          />
+        </div>
+
+        <div className="wizard-footer">
+          <button
+            type="button"
+            onClick={this.goToPreviousStep}
+            disabled={!canGoBack || isSubmitting}
+          >
+            Previous
+          </button>
+
+          {!isLastStep ? (
+            <button type="button" onClick={this.goToNextStep} disabled={isSubmitting}>
+              Next
+            </button>
+          ) : (
+            <button type="button" onClick={this.handleSubmit} disabled={isSubmitting}>
+              {isSubmitting ? "Submitting..." : "Complete"}
+            </button>
+          )}
+
+          {errors.submit && <div className="error-message">{errors.submit}</div>}
+        </div>
+      </div>
+    )
+  }
+}
+
+export default FormWizard

--- a/self-test/src/components/FormWizard.tsx
+++ b/self-test/src/components/FormWizard.tsx
@@ -36,9 +36,9 @@ class FormWizard extends React.Component<FormWizardProps, FormWizardState> {
     super(props)
 
     // Initialize refs for each step
-    props.steps.forEach((step) => {
+    for (const step of props.steps) {
       this.formRefs[step.id] = React.createRef()
-    })
+    }
 
     this.state = {
       currentStepIndex: 0,
@@ -71,7 +71,7 @@ class FormWizard extends React.Component<FormWizardProps, FormWizardState> {
     window.addEventListener("beforeunload", this.handleBeforeUnload)
   }
 
-  componentDidUpdate(prevProps: FormWizardProps, prevState: FormWizardState) {
+  componentDidUpdate(_prevProps: FormWizardProps, prevState: FormWizardState) {
     if (prevState.currentStepIndex !== this.state.currentStepIndex) {
       this.focusCurrentStep()
 
@@ -105,7 +105,7 @@ class FormWizard extends React.Component<FormWizardProps, FormWizardState> {
     const currentStep = this.props.steps[this.state.currentStepIndex]
     const stepRef = this.formRefs[currentStep.id]
 
-    if (stepRef.current && stepRef.current.focus) {
+    if (stepRef.current?.focus) {
       setTimeout(() => stepRef.current.focus(), 100)
     }
   }
@@ -143,11 +143,10 @@ class FormWizard extends React.Component<FormWizardProps, FormWizardState> {
           errors: { ...this.state.errors, [currentStep.id]: error },
         })
         return false
-      } else {
-        const newErrors = { ...this.state.errors }
-        delete newErrors[currentStep.id]
-        this.setState({ errors: newErrors })
       }
+      const newErrors = { ...this.state.errors }
+      delete newErrors[currentStep.id]
+      this.setState({ errors: newErrors })
     }
 
     return true
@@ -223,7 +222,7 @@ class FormWizard extends React.Component<FormWizardProps, FormWizardState> {
     const CurrentStepComponent = currentStep.component
 
     const canGoBack = history.length > 1
-    const canGoNext = currentStepIndex < steps.length - 1
+    const _canGoNext = currentStepIndex < steps.length - 1
     const isLastStep = currentStepIndex === steps.length - 1
 
     return (
@@ -231,7 +230,8 @@ class FormWizard extends React.Component<FormWizardProps, FormWizardState> {
         <div className="wizard-header">
           <div className="step-indicator">
             {steps.map((step, index) => (
-              <div
+              <button
+                type="button"
                 key={step.id}
                 className={`step ${index === currentStepIndex ? "active" : ""} ${
                   index < currentStepIndex ? "completed" : ""
@@ -239,7 +239,7 @@ class FormWizard extends React.Component<FormWizardProps, FormWizardState> {
                 onClick={() => this.goToStep(index)}
               >
                 {step.title}
-              </div>
+              </button>
             ))}
           </div>
 

--- a/self-test/src/components/UserCard.tsx
+++ b/self-test/src/components/UserCard.tsx
@@ -1,0 +1,72 @@
+import React from "react"
+
+interface User {
+  id: number
+  name: string
+  email: string
+  avatar?: string
+}
+
+interface UserCardProps {
+  user: User
+  onClick?: (user: User) => void
+  showAvatar?: boolean
+}
+
+interface UserCardState {
+  isHovered: boolean
+  isLoading: boolean
+}
+
+/**
+ * A basic user card component that needs conversion to hooks.
+ * This represents step 1: simple class component with minimal state.
+ */
+class UserCard extends React.Component<UserCardProps, UserCardState> {
+  constructor(props: UserCardProps) {
+    super(props)
+    this.state = {
+      isHovered: false,
+      isLoading: false,
+    }
+  }
+
+  handleMouseEnter = () => {
+    this.setState({ isHovered: true })
+  }
+
+  handleMouseLeave = () => {
+    this.setState({ isHovered: false })
+  }
+
+  handleClick = () => {
+    if (this.props.onClick) {
+      this.props.onClick(this.props.user)
+    }
+  }
+
+  render() {
+    const { user, showAvatar = true } = this.props
+    const { isHovered, isLoading } = this.state
+
+    return (
+      <div
+        className={`user-card ${isHovered ? "hovered" : ""}`}
+        onMouseEnter={this.handleMouseEnter}
+        onMouseLeave={this.handleMouseLeave}
+        onClick={this.handleClick}
+      >
+        {showAvatar && user.avatar && (
+          <img src={user.avatar} alt={`${user.name} avatar`} className="avatar" />
+        )}
+        <div className="user-info">
+          <h3>{user.name}</h3>
+          <p>{user.email}</p>
+        </div>
+        {isLoading && <div className="loading">Loading...</div>}
+      </div>
+    )
+  }
+}
+
+export default UserCard

--- a/self-test/src/components/UserCard.tsx
+++ b/self-test/src/components/UserCard.tsx
@@ -50,7 +50,8 @@ class UserCard extends React.Component<UserCardProps, UserCardState> {
     const { isHovered, isLoading } = this.state
 
     return (
-      <div
+      <button
+        type="button"
         className={`user-card ${isHovered ? "hovered" : ""}`}
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
@@ -64,7 +65,7 @@ class UserCard extends React.Component<UserCardProps, UserCardState> {
           <p>{user.email}</p>
         </div>
         {isLoading && <div className="loading">Loading...</div>}
-      </div>
+      </button>
     )
   }
 }

--- a/self-test/src/components/index.ts
+++ b/self-test/src/components/index.ts
@@ -1,0 +1,3 @@
+export { default as UserCard } from "./UserCard"
+export { default as DataFetcher } from "./DataFetcher"
+export { default as FormWizard } from "./FormWizard"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
         "**/*.config.ts",
         // Example/fixture files - not application code
         "examples/**",
+        "self-test/**",
         // CLI scripts - require integration testing
         "src/scripts/**",
         // Entry points - require full integration setup


### PR DESCRIPTION
- Create self-test/ directory with React class components of increasing complexity
- Add 3-step migration plan targeting UserCard, DataFetcher, and FormWizard components
- Include intentionally unoptimized test plan to validate plan optimization
- Configure .hachiko.yml with self-test allowlist and migration directory
- Components cover: basic state, lifecycle methods, refs, and advanced patterns

This enables end-to-end testing of Hachiko's migration capabilities within the repo itself.