### PR TITLE
Increase test coverage from 39.88% to 55.53%

### DIFF
--- a/test/unit/services/issues.test.ts
+++ b/test/unit/services/issues.test.ts
@@ -1,0 +1,375 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the logger
+vi.mock("../../../src/utils/logger.js", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(() => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    })),
+  }),
+}));
+
+// Mock plans service
+vi.mock("../../../src/services/plans.js", () => ({
+  generateNormalizedFrontmatter: vi.fn(),
+  serializeFrontmatter: vi.fn(),
+}));
+
+import {
+  createMigrationIssue,
+  createPlanReviewPR,
+} from "../../../src/services/issues.js";
+import { generateNormalizedFrontmatter, serializeFrontmatter } from "../../../src/services/plans.js";
+import { createMockContext } from "../../mocks/github.js";
+import { createLogger } from "../../../src/utils/logger.js";
+
+describe("createMigrationIssue", () => {
+  let mockContext: any;
+  let mockOctokit: any;
+  let mockLogger: any;
+
+  beforeEach(() => {
+    mockOctokit = {
+      issues: {
+        create: vi.fn(),
+      },
+    };
+
+    mockContext = createMockContext(
+      "push",
+      {
+        repository: {
+          owner: { login: "test-owner" },
+          name: "test-repo",
+        },
+      },
+      mockOctokit
+    );
+
+    mockLogger = createLogger("test");
+    vi.clearAllMocks();
+  });
+
+  it("should create migration issue with correct title and labels", async () => {
+    const mockPlan = {
+      id: "react-upgrade",
+      frontmatter: {
+        id: "react-upgrade",
+        title: "Upgrade to React 18",
+        owner: "@frontend-team",
+        status: "draft" as const,
+        strategy: { chunkBy: "module" as const, maxOpenPRs: 2 },
+        checks: ["npm test"],
+        rollback: [{ description: "Revert", command: "revert" }],
+        successCriteria: ["All tests pass"],
+        steps: [{ id: "step1", description: "Update components" }],
+        dependsOn: [],
+        touches: ["src/**"],
+        attempts: 0,
+      },
+      content: "Migration plan content",
+      filePath: "migrations/react-upgrade.md",
+    };
+
+    const mockConfig = {
+      defaults: {
+        labels: ["hachiko", "migration"],
+      },
+    };
+
+    mockOctokit.issues.create.mockResolvedValue({
+      data: {
+        number: 123,
+        html_url: "https://github.com/test-owner/test-repo/issues/123",
+      },
+    });
+
+    await createMigrationIssue(mockContext, mockPlan, mockConfig as any, mockLogger);
+
+    expect(mockOctokit.issues.create).toHaveBeenCalledWith({
+      owner: "test-owner",
+      repo: "test-repo",
+      title: "[Migration] Upgrade to React 18",
+      body: expect.stringContaining("react-upgrade"),
+      labels: [
+        "hachiko",
+        "migration",
+        "hachiko:plan:react-upgrade",
+        "hachiko:status:draft",
+        "hachiko",
+        "migration",
+      ],
+    });
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { planId: "react-upgrade" },
+      "Creating Migration Issue"
+    );
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      {
+        planId: "react-upgrade",
+        issueNumber: 123,
+        issueUrl: "https://github.com/test-owner/test-repo/issues/123",
+      },
+      "Created Migration Issue"
+    );
+  });
+
+  it("should handle GitHub API errors gracefully", async () => {
+    const mockPlan = {
+      id: "test-plan",
+      frontmatter: {
+        id: "test-plan",
+        title: "Test Plan",
+        owner: "@team",
+        status: "draft" as const,
+        strategy: { chunkBy: "module" as const, maxOpenPRs: 1 },
+        checks: [],
+        rollback: [],
+        successCriteria: [],
+        steps: [],
+        dependsOn: [],
+        touches: [],
+        attempts: 0,
+      },
+      content: "",
+      filePath: "",
+    };
+
+    const mockConfig = {
+      defaults: { labels: ["hachiko"] },
+    };
+
+    const apiError = new Error("GitHub API Error");
+    mockOctokit.issues.create.mockRejectedValue(apiError);
+
+    await expect(
+      createMigrationIssue(mockContext, mockPlan, mockConfig as any, mockLogger)
+    ).rejects.toThrow("GitHub API Error");
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      { error: apiError, planId: "test-plan" },
+      "Failed to create Migration Issue"
+    );
+  });
+});
+
+describe("createPlanReviewPR", () => {
+  let mockContext: any;
+  let mockOctokit: any;
+  let mockLogger: any;
+
+  beforeEach(() => {
+    mockOctokit = {
+      git: {
+        createRef: vi.fn(),
+      },
+      repos: {
+        createOrUpdateFileContents: vi.fn(),
+        getBranch: vi.fn(),
+      },
+      pulls: {
+        create: vi.fn(),
+      },
+      issues: {
+        addLabels: vi.fn(),
+      },
+    };
+
+    mockContext = createMockContext(
+      "push",
+      {
+        repository: {
+          owner: { login: "test-owner" },
+          name: "test-repo",
+          default_branch: "main",
+        },
+      },
+      mockOctokit
+    );
+
+    mockLogger = createLogger("test");
+    
+    // Mock the plans service functions
+    vi.mocked(generateNormalizedFrontmatter).mockReturnValue({
+      id: "test-plan",
+      title: "Test Plan",
+      owner: "@team",
+      status: "draft",
+      strategy: { chunkBy: "module", maxOpenPRs: 1 },
+      checks: [],
+      rollback: [],
+      successCriteria: [],
+      steps: [],
+      dependsOn: [],
+      touches: [],
+      attempts: 0,
+    } as any);
+
+    vi.mocked(serializeFrontmatter).mockReturnValue("id: test-plan\ntitle: Test Plan");
+
+    vi.clearAllMocks();
+  });
+
+  it("should create plan review PR with normalized frontmatter", async () => {
+    const mockPlan = {
+      id: "test-plan",
+      frontmatter: {
+        id: "test-plan",
+        title: "Test Plan",
+        owner: "@team",
+        status: "draft" as const,
+        strategy: { chunkBy: "module" as const, maxOpenPRs: 1 },
+        checks: [],
+        rollback: [],
+        successCriteria: [],
+        steps: [],
+        dependsOn: [],
+        touches: [],
+        attempts: 0,
+      },
+      content: "Plan content here",
+      filePath: "migrations/test-plan.md",
+    };
+
+    const mockConfig = {
+      defaults: { labels: ["hachiko"] },
+    };
+
+    // Mock successful API responses
+    mockOctokit.repos.getBranch.mockResolvedValue({
+      data: { commit: { sha: "main-sha-123" } },
+    });
+
+    mockOctokit.git.createRef.mockResolvedValue({});
+    mockOctokit.repos.createOrUpdateFileContents.mockResolvedValue({});
+    mockOctokit.pulls.create.mockResolvedValue({
+      data: {
+        number: 456,
+        html_url: "https://github.com/test-owner/test-repo/pull/456",
+      },
+    });
+    mockOctokit.issues.addLabels.mockResolvedValue({});
+
+    await createPlanReviewPR(mockContext, mockPlan, mockConfig as any, mockLogger);
+
+    expect(generateNormalizedFrontmatter).toHaveBeenCalledWith(mockPlan.frontmatter, mockConfig);
+    expect(serializeFrontmatter).toHaveBeenCalled();
+
+    expect(mockOctokit.git.createRef).toHaveBeenCalledWith({
+      owner: "test-owner",
+      repo: "test-repo",
+      ref: "refs/heads/hachi/plan-review/test-plan",
+      sha: "main-sha-123",
+    });
+
+    expect(mockOctokit.repos.createOrUpdateFileContents).toHaveBeenCalledWith({
+      owner: "test-owner",
+      repo: "test-repo",
+      path: "migrations/test-plan.md",
+      message: "Hachiko: Normalize plan frontmatter for test-plan",
+      content: expect.any(String),
+      branch: "hachi/plan-review/test-plan",
+    });
+
+    expect(mockOctokit.pulls.create).toHaveBeenCalledWith({
+      owner: "test-owner",
+      repo: "test-repo",
+      title: "[Plan Review] Test Plan",
+      head: "hachi/plan-review/test-plan",
+      base: "main",
+      body: expect.stringContaining("test-plan"),
+    });
+  });
+
+  it("should handle errors during PR creation", async () => {
+    const mockPlan = {
+      id: "error-plan",
+      frontmatter: {
+        id: "error-plan",
+        title: "Error Plan",
+        owner: "@team",
+        status: "draft" as const,
+        strategy: { chunkBy: "module" as const, maxOpenPRs: 1 },
+        checks: [],
+        rollback: [],
+        successCriteria: [],
+        steps: [],
+        dependsOn: [],
+        touches: [],
+        attempts: 0,
+      },
+      content: "content",
+      filePath: "migrations/error-plan.md",
+    };
+
+    const mockConfig = { defaults: { labels: [] } };
+
+    const gitError = new Error("Failed to create branch");
+    mockOctokit.repos.getBranch.mockRejectedValue(gitError);
+
+    await expect(
+      createPlanReviewPR(mockContext, mockPlan, mockConfig as any, mockLogger)
+    ).rejects.toThrow("Failed to create branch");
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      { error: gitError, planId: "error-plan" },
+      "Failed to create Plan Review PR"
+    );
+  });
+
+  it("should generate correct PR body with plan details", async () => {
+    const mockPlan = {
+      id: "detailed-plan",
+      frontmatter: {
+        id: "detailed-plan",
+        title: "Detailed Migration Plan",
+        owner: "@senior-team",
+        status: "draft" as const,
+        strategy: { chunkBy: "package" as const, maxOpenPRs: 3 },
+        checks: ["npm test", "npm run lint"],
+        rollback: [{ description: "Rollback step", command: "git revert" }],
+        successCriteria: ["All tests pass", "No linting errors"],
+        steps: [
+          { id: "step1", description: "First step" },
+          { id: "step2", description: "Second step" },
+        ],
+        dependsOn: ["dependency-plan"],
+        touches: ["src/**", "test/**"],
+        attempts: 0,
+      },
+      content: "Detailed plan content",
+      filePath: "migrations/detailed-plan.md",
+    };
+
+    const mockConfig = { defaults: { labels: ["migration"] } };
+
+    mockOctokit.repos.getBranch.mockResolvedValue({
+      data: { commit: { sha: "branch-sha" } },
+    });
+    mockOctokit.git.createRef.mockResolvedValue({});
+    mockOctokit.repos.createOrUpdateFileContents.mockResolvedValue({});
+    mockOctokit.pulls.create.mockResolvedValue({
+      data: { number: 789, html_url: "https://github.com/test/repo/pull/789" },
+    });
+    mockOctokit.issues.addLabels.mockResolvedValue({});
+
+    await createPlanReviewPR(mockContext, mockPlan, mockConfig as any, mockLogger);
+
+    const createPRCall = mockOctokit.pulls.create.mock.calls[0][0];
+    const prBody = createPRCall.body;
+
+    expect(prBody).toContain("detailed-plan");
+    expect(prBody).toContain("Detailed Migration Plan");
+    expect(prBody).toContain("@senior-team");
+    // The actual PR body template doesn't include step count
+  });
+});

--- a/test/unit/services/plans.test.ts
+++ b/test/unit/services/plans.test.ts
@@ -1,0 +1,547 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readFile } from "node:fs/promises";
+
+// Mock the logger
+vi.mock("../../../src/utils/logger.js", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(() => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    })),
+  }),
+}));
+
+// Mock fs with proper structure
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(),
+}));
+
+// Mock glob
+vi.mock("glob", () => ({
+  glob: vi.fn(),
+}));
+
+import {
+  parsePlanFile,
+  discoverPlans,
+  generateNormalizedFrontmatter,
+  serializeFrontmatter,
+  validatePlanDependencies,
+  type MigrationPlan,
+} from "../../../src/services/plans.js";
+import { glob } from "glob";
+
+describe("parsePlanFile", () => {
+  const mockReadFile = vi.mocked(readFile);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should parse a valid migration plan file", async () => {
+    const validPlanContent = `---
+id: react-upgrade
+title: "Upgrade React Components to v18"
+owner: "@frontend-team"
+status: draft
+strategy:
+  chunkBy: module
+  maxOpenPRs: 2
+checks:
+  - "npm test"
+  - "npm run typecheck"
+rollback:
+  - description: "Revert React version"
+    command: "npm install react@17"
+successCriteria:
+  - "All components use React 18 features"
+steps:
+  - id: step1
+    description: "Update function components"
+    agent: claude-cli
+dependsOn: []
+touches: ["src/components/**"]
+attempts: 0
+---
+
+# React Upgrade Migration
+
+This migration upgrades all React components to use React 18 features.
+
+## Overview
+
+We will systematically upgrade components to use modern React patterns.
+`;
+
+    mockReadFile.mockResolvedValue(validPlanContent);
+
+    const result = await parsePlanFile("migrations/react-upgrade.md");
+
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.plan.id).toBe("react-upgrade");
+    expect(result.plan.frontmatter.title).toBe("Upgrade React Components to v18");
+    expect(result.plan.frontmatter.status).toBe("draft");
+    expect(result.plan.frontmatter.steps).toHaveLength(1);
+    expect(result.plan.frontmatter.steps[0].id).toBe("step1");
+    expect(result.plan.content).toContain("# React Upgrade Migration");
+  });
+
+  it("should handle invalid frontmatter gracefully", async () => {
+    const invalidPlanContent = `---
+id: invalid-plan
+# Missing required fields and invalid YAML structure
+strategy: invalid-strategy-value
+steps: not-an-array
+---
+
+Some content here.
+`;
+
+    mockReadFile.mockResolvedValue(invalidPlanContent);
+
+    const result = await parsePlanFile("migrations/invalid-plan.md");
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toContain("Invalid frontmatter:");
+    expect(result.plan.id).toBe("invalid-plan"); // Should still extract basic info
+  });
+
+  it("should validate that plans have at least one step", async () => {
+    const planWithoutSteps = `---
+id: empty-plan
+title: "Empty Plan"
+owner: "@test-team"
+status: draft
+strategy:
+  chunkBy: module
+steps: []
+dependsOn: []
+touches: []
+attempts: 0
+---
+
+This plan has no steps.
+`;
+
+    mockReadFile.mockResolvedValue(planWithoutSteps);
+
+    const result = await parsePlanFile("migrations/empty-plan.md");
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain("Migration plan must have at least one step");
+  });
+
+  it("should detect duplicate step IDs", async () => {
+    const planWithDuplicateSteps = `---
+id: duplicate-steps
+title: "Plan with Duplicate Steps"
+owner: "@test-team"
+status: draft
+strategy:
+  chunkBy: module
+steps:
+  - id: step1
+    description: "First step"
+  - id: step1
+    description: "Duplicate step"
+  - id: step2
+    description: "Second step"
+dependsOn: []
+touches: []
+attempts: 0
+---
+
+This plan has duplicate step IDs.
+`;
+
+    mockReadFile.mockResolvedValue(planWithDuplicateSteps);
+
+    const result = await parsePlanFile("migrations/duplicate-steps.md");
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain("Duplicate step IDs found: step1");
+  });
+
+  it("should validate that content is not empty", async () => {
+    const planWithoutContent = `---
+id: no-content
+title: "Plan without content"
+owner: "@test-team"
+status: draft
+strategy:
+  chunkBy: module
+steps:
+  - id: step1
+    description: "Test step"
+dependsOn: []
+touches: []
+attempts: 0
+---
+
+`;
+
+    mockReadFile.mockResolvedValue(planWithoutContent);
+
+    const result = await parsePlanFile("migrations/no-content.md");
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain("Migration plan content cannot be empty");
+  });
+
+  it("should handle file read errors", async () => {
+    mockReadFile.mockRejectedValue(new Error("File not found"));
+
+    const result = await parsePlanFile("nonexistent.md");
+    
+    expect(result.isValid).toBe(false);
+    expect(result.errors[0]).toContain("Failed to read plan file:");
+  });
+
+  it("should handle malformed frontmatter gracefully", async () => {
+    const malformedContent = `---
+invalid yaml: [unclosed
+---
+
+Content here.
+`;
+
+    mockReadFile.mockResolvedValue(malformedContent);
+
+    const result = await parsePlanFile("migrations/malformed.md");
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe("discoverPlans", () => {
+  const mockGlob = vi.mocked(glob);
+  const mockConfig = {
+    plans: { 
+      directory: "migrations/",
+      filenamePattern: "*.md" 
+    }
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should discover plan files in directory", async () => {
+    const planFiles = [
+      "/repo/migrations/plan1.md",
+      "/repo/migrations/plan2.md"
+    ];
+
+    mockGlob.mockResolvedValue(planFiles);
+
+    const result = await discoverPlans("/repo", mockConfig as any);
+
+    expect(result).toEqual(planFiles);
+    expect(mockGlob).toHaveBeenCalledWith(
+      expect.stringContaining("migrations/*.md"),
+      expect.objectContaining({
+        cwd: "/repo",
+        absolute: true,
+        ignore: ["**/node_modules/**", "**/.git/**"]
+      })
+    );
+  });
+
+  it("should handle empty directory", async () => {
+    mockGlob.mockResolvedValue([]);
+
+    const result = await discoverPlans("/repo", mockConfig as any);
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("validatePlanDependencies", () => {
+  it("should detect missing dependencies", () => {
+    const plans: MigrationPlan[] = [
+      {
+        id: "plan1",
+        frontmatter: {
+          id: "plan1",
+          title: "Plan 1",
+          owner: "@team",
+          status: "draft",
+          strategy: { chunkBy: "module", maxOpenPRs: 1 },
+          checks: [],
+          rollback: [],
+          successCriteria: [],
+          steps: [],
+          dependsOn: ["nonexistent-plan"],
+          touches: [],
+          attempts: 0,
+        },
+        content: "",
+        filePath: "",
+      },
+    ];
+
+    const errors = validatePlanDependencies(plans);
+
+    expect(errors).toContain('Plan "plan1" depends on non-existent plan "nonexistent-plan"');
+  });
+
+  it("should detect circular dependencies", () => {
+    const plans: MigrationPlan[] = [
+      {
+        id: "plan1",
+        frontmatter: {
+          id: "plan1",
+          title: "Plan 1", 
+          owner: "@team",
+          status: "draft",
+          strategy: { chunkBy: "module", maxOpenPRs: 1 },
+          checks: [],
+          rollback: [],
+          successCriteria: [],
+          steps: [],
+          dependsOn: ["plan2"],
+          touches: [],
+          attempts: 0,
+        },
+        content: "",
+        filePath: "",
+      },
+      {
+        id: "plan2",
+        frontmatter: {
+          id: "plan2",
+          title: "Plan 2",
+          owner: "@team", 
+          status: "draft",
+          strategy: { chunkBy: "module", maxOpenPRs: 1 },
+          checks: [],
+          rollback: [],
+          successCriteria: [],
+          steps: [],
+          dependsOn: ["plan1"], // Circular dependency
+          touches: [],
+          attempts: 0,
+        },
+        content: "",
+        filePath: "",
+      },
+    ];
+
+    const errors = validatePlanDependencies(plans);
+
+    expect(errors.some(error => error.includes("Circular dependency detected"))).toBe(true);
+  });
+
+  it("should pass validation for valid dependencies", () => {
+    const plans: MigrationPlan[] = [
+      {
+        id: "plan1",
+        frontmatter: {
+          id: "plan1",
+          title: "Plan 1",
+          owner: "@team",
+          status: "draft",
+          strategy: { chunkBy: "module", maxOpenPRs: 1 },
+          checks: [],
+          rollback: [],
+          successCriteria: [],
+          steps: [],
+          dependsOn: [],
+          touches: [],
+          attempts: 0,
+        },
+        content: "",
+        filePath: "",
+      },
+      {
+        id: "plan2", 
+        frontmatter: {
+          id: "plan2",
+          title: "Plan 2",
+          owner: "@team",
+          status: "draft", 
+          strategy: { chunkBy: "module", maxOpenPRs: 1 },
+          checks: [],
+          rollback: [],
+          successCriteria: [],
+          steps: [],
+          dependsOn: ["plan1"], // Valid dependency
+          touches: [],
+          attempts: 0,
+        },
+        content: "",
+        filePath: "",
+      },
+    ];
+
+    const errors = validatePlanDependencies(plans);
+
+    expect(errors).toEqual([]);
+  });
+});
+
+describe("generateNormalizedFrontmatter", () => {
+  const mockConfig = {
+    defaults: {
+      agent: "claude-cli",
+      labels: ["hachiko", "migration"],
+    },
+    agents: {
+      "claude-cli": {
+        kind: "cli",
+        command: "claude",
+      },
+    },
+  };
+
+  it("should apply defaults to incomplete frontmatter", () => {
+    const incompleteFrontmatter = {
+      id: "test-plan",
+      title: "Test Plan",
+      owner: "@team",
+      status: "draft" as const,
+      strategy: { chunkBy: "module" as const, maxOpenPRs: 1 },
+      checks: [],
+      rollback: [],
+      successCriteria: [],
+      steps: [],
+      dependsOn: [],
+      touches: [],
+      attempts: 0,
+      // Missing agent field - should use default
+    };
+
+    const normalized = generateNormalizedFrontmatter(incompleteFrontmatter, mockConfig);
+
+    // Should apply default agent
+    expect(normalized.agent).toBe("claude-cli");
+    
+    // Should generate default steps if none provided
+    expect(normalized.steps).toHaveLength(3);
+    expect(normalized.steps[0].id).toBe("detect");
+    expect(normalized.steps[1].id).toBe("implement");
+    expect(normalized.steps[2].id).toBe("verify");
+  });
+
+  it("should preserve existing values when they exist", () => {
+    const completeFrontmatter = {
+      id: "test-plan",
+      title: "Test Plan",
+      owner: "@team",
+      status: "active" as const,
+      strategy: { chunkBy: "package" as const, maxOpenPRs: 3 },
+      checks: [{ name: "test", command: "npm test" }],
+      rollback: [{ description: "rollback", commands: ["git revert"] }],
+      successCriteria: ["All tests pass"],
+      steps: [
+        {
+          id: "step1",
+          description: "Test step",
+          agent: "custom-agent",
+        },
+      ],
+      dependsOn: [],
+      touches: ["src/**"],
+      attempts: 2,
+    };
+
+    const normalized = generateNormalizedFrontmatter(completeFrontmatter, mockConfig);
+
+    expect(normalized.status).toBe("active");
+    expect(normalized.strategy.chunkBy).toBe("package");
+    expect(normalized.steps[0].agent).toBe("custom-agent");
+    expect(normalized.attempts).toBe(2);
+  });
+});
+
+describe("serializeFrontmatter", () => {
+  it("should serialize frontmatter to valid YAML", () => {
+    const frontmatter = {
+      id: "test-plan",
+      title: "Test Migration Plan",
+      owner: "@frontend-team",
+      status: "draft" as const,
+      strategy: {
+        chunkBy: "module" as const,
+        maxOpenPRs: 2,
+      },
+      checks: [
+        {
+          name: "TypeScript compilation",
+          command: "tsc --noEmit",
+        },
+      ],
+      rollback: [
+        {
+          description: "Revert changes",
+          commands: ["git revert HEAD"],
+        },
+      ],
+      successCriteria: [
+        "All TypeScript errors resolved",
+        "Tests pass",
+      ],
+      steps: [
+        {
+          id: "update-imports",
+          description: "Update import statements",
+          agent: "claude-cli",
+          prompt: "Update all import statements to use ES modules",
+        },
+      ],
+      dependsOn: [],
+      touches: ["src/**/*.ts"],
+      attempts: 0,
+    };
+
+    const yaml = serializeFrontmatter(frontmatter);
+
+    expect(yaml).toContain("id: test-plan");
+    expect(yaml).toContain("title: Test Migration Plan");
+    expect(yaml).toContain("status: draft");
+    expect(yaml).toContain("chunkBy: module");
+    expect(yaml).toContain("- name: TypeScript compilation");
+    expect(yaml).toContain("- id: update-imports");
+    
+    // Should be valid YAML (no parsing errors when re-parsing)
+    expect(() => {
+      const matter = require("gray-matter");
+      matter(`---\n${yaml}\n---\nContent`);
+    }).not.toThrow();
+  });
+
+  it("should handle empty arrays and objects correctly", () => {
+    const minimalFrontmatter = {
+      id: "minimal",
+      title: "Minimal Plan",
+      owner: "@team",
+      status: "draft" as const,
+      strategy: {
+        chunkBy: "module" as const,
+        maxOpenPRs: 1,
+      },
+      checks: [],
+      rollback: [],
+      successCriteria: [],
+      steps: [],
+      dependsOn: [],
+      touches: [],
+      attempts: 0,
+    };
+
+    const yaml = serializeFrontmatter(minimalFrontmatter);
+
+    expect(yaml).toContain("checks: []");
+    expect(yaml).toContain("steps: []");
+    expect(yaml).toContain("dependsOn: []");
+  });
+});

--- a/test/unit/webhooks/pull_request.test.ts
+++ b/test/unit/webhooks/pull_request.test.ts
@@ -1,0 +1,280 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the services before importing modules that use them
+vi.mock("../../../src/services/config.js", () => ({
+  loadHachikoConfig: vi.fn(),
+}));
+
+vi.mock("../../../src/services/migrations.js", () => ({
+  updateMigrationProgress: vi.fn(),
+  emitNextStep: vi.fn(),
+}));
+
+// Mock the logger
+vi.mock("../../../src/utils/logger.js", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(() => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    })),
+  }),
+}));
+
+// Mock the git utils
+vi.mock("../../../src/utils/git.js", () => ({
+  parseMigrationBranchName: vi.fn().mockReturnValue(null),
+}));
+
+import { handlePullRequest } from "../../../src/webhooks/pull_request.js";
+import { loadHachikoConfig } from "../../../src/services/config.js";
+import { updateMigrationProgress, emitNextStep } from "../../../src/services/migrations.js";
+import { createMockContext } from "../../mocks/github.js";
+import { createLogger } from "../../../src/utils/logger.js";
+
+describe("handlePullRequest", () => {
+  let mockContext: any;
+  let mockOctokit: any;
+  let mockLogger: any;
+
+  beforeEach(() => {
+    mockOctokit = {
+      issues: {
+        listForRepo: vi.fn(),
+        createComment: vi.fn(),
+      },
+    };
+    
+    mockContext = createMockContext(
+      "pull_request.closed",
+      {
+        repository: {
+          owner: { login: "test-owner" },
+          name: "test-repo",
+        },
+        pull_request: {
+          number: 123,
+          title: "Regular PR", 
+          merged: false,
+          html_url: "https://github.com/test-owner/test-repo/pull/123",
+          merge_commit_sha: null,
+          labels: [],
+        },
+      },
+      mockOctokit
+    );
+
+    mockLogger = createLogger("test");
+    vi.clearAllMocks();
+  });
+
+  describe("when PR is not a migration PR", () => {
+    beforeEach(() => {
+      mockContext.payload.pull_request.labels = [];
+    });
+
+    it("should skip processing non-Hachiko PRs", async () => {
+      await handlePullRequest(mockContext, mockLogger);
+
+      expect(mockLogger.debug).toHaveBeenCalledWith("PR is not managed by Hachiko, skipping");
+      expect(loadHachikoConfig).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when PR is a migration PR", () => {
+    beforeEach(() => {
+      mockContext.payload.pull_request.labels = [
+        { name: "hachiko" },
+        { name: "migration" },
+        { name: "hachiko:plan:react-upgrade" },
+        { name: "hachiko:step:react-upgrade:step1:src" },
+      ];
+      mockContext.payload.pull_request.head = {
+        ref: "hachiko/react-upgrade/step1/src"
+      };
+      vi.mocked(loadHachikoConfig).mockResolvedValue({
+        plans: { directory: "migrations/" },
+        defaults: { agent: "claude-cli" },
+      });
+    });
+
+    describe("and PR was merged", () => {
+      beforeEach(() => {
+        mockContext.payload.pull_request.merged = true;
+        mockContext.payload.pull_request.merge_commit_sha = "abc123";
+        vi.mocked(updateMigrationProgress).mockResolvedValue(undefined);
+        vi.mocked(emitNextStep).mockResolvedValue(undefined);
+      });
+
+      it("should handle merged PR correctly", async () => {
+        await handlePullRequest(mockContext, mockLogger);
+
+        expect(loadHachikoConfig).toHaveBeenCalledWith(mockContext);
+        expect(updateMigrationProgress).toHaveBeenCalledWith(
+          mockContext,
+          "react-upgrade", 
+          "step1",
+          "completed",
+          {
+            prNumber: 123,
+            mergeCommit: "abc123",
+            chunk: "src",
+          },
+          mockLogger
+        );
+        expect(emitNextStep).toHaveBeenCalledWith(
+          mockContext,
+          "react-upgrade",
+          "step1", 
+          "src",
+          mockLogger
+        );
+      });
+
+      it("should handle migration metadata extraction correctly", async () => {
+        await handlePullRequest(mockContext, mockLogger);
+
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          { migrationMeta: { planId: "react-upgrade", stepId: "step1", chunk: "src" } },
+          "Extracted migration metadata"
+        );
+      });
+    });
+
+    describe("and PR was closed without merging", () => {
+      beforeEach(() => {
+        mockContext.payload.pull_request.merged = false;
+        vi.mocked(updateMigrationProgress).mockResolvedValue(undefined);
+        mockOctokit.issues.listForRepo.mockResolvedValue({
+          data: [{ number: 456, title: "Migration: react-upgrade" }]
+        });
+        mockOctokit.issues.createComment.mockResolvedValue({});
+      });
+
+      it("should handle closed PR correctly", async () => {
+        await handlePullRequest(mockContext, mockLogger);
+
+        expect(updateMigrationProgress).toHaveBeenCalledWith(
+          mockContext,
+          "react-upgrade",
+          "step1", 
+          "skipped",
+          {
+            prNumber: 123,
+            chunk: "src",
+            reason: "PR closed without merging",
+          },
+          mockLogger
+        );
+      });
+
+      it("should add skipped step comment to migration issue", async () => {
+        await handlePullRequest(mockContext, mockLogger);
+
+        expect(mockOctokit.issues.listForRepo).toHaveBeenCalledWith({
+          owner: "test-owner",
+          repo: "test-repo",
+          labels: "hachiko:plan:react-upgrade",
+          state: "open",
+        });
+
+        expect(mockOctokit.issues.createComment).toHaveBeenCalledWith({
+          owner: "test-owner",
+          repo: "test-repo", 
+          issue_number: 456,
+          body: expect.stringContaining("⚠️ **Step Skipped**: `step1` (src)"),
+        });
+      });
+
+      it("should handle missing migration issue gracefully", async () => {
+        mockOctokit.issues.listForRepo.mockResolvedValue({ data: [] });
+
+        await handlePullRequest(mockContext, mockLogger);
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          { planId: "react-upgrade" },
+          "No open Migration Issue found"
+        );
+        expect(mockOctokit.issues.createComment).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when migration metadata cannot be extracted", () => {
+      beforeEach(() => {
+        mockContext.payload.pull_request.labels = [
+          { name: "hachiko" },
+          { name: "migration" },
+          // No hachiko:step: label, so metadata extraction will fail
+        ];
+        mockContext.payload.pull_request.head = undefined; // No branch ref to avoid require issue
+      });
+
+      it("should handle invalid migration metadata gracefully", async () => {
+        await handlePullRequest(mockContext, mockLogger);
+
+        expect(mockLogger.warn).toHaveBeenCalledWith("Could not extract migration metadata from PR");
+        expect(updateMigrationProgress).not.toHaveBeenCalled();
+        expect(emitNextStep).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when an error occurs", () => {
+      beforeEach(() => {
+        vi.mocked(loadHachikoConfig).mockRejectedValue(new Error("Config load failed"));
+      });
+
+      it("should log error and rethrow", async () => {
+        await expect(handlePullRequest(mockContext, mockLogger)).rejects.toThrow("Config load failed");
+
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          { error: expect.any(Error) },
+          "Failed to handle pull request event"
+        );
+      });
+    });
+
+    describe("when no chunk is specified in PR title", () => {
+      beforeEach(() => {
+        mockContext.payload.pull_request.labels = [
+          { name: "hachiko" },
+          { name: "migration" },
+          { name: "hachiko:plan:react-upgrade" },
+          { name: "hachiko:step:react-upgrade:step1" }, // No chunk specified
+        ];
+        mockContext.payload.pull_request.merged = false;
+        vi.mocked(updateMigrationProgress).mockResolvedValue(undefined);
+        mockOctokit.issues.listForRepo.mockResolvedValue({
+          data: [{ number: 456, title: "Migration: react-upgrade" }]
+        });
+      });
+
+      it("should handle undefined chunk correctly", async () => {
+        await handlePullRequest(mockContext, mockLogger);
+
+        expect(updateMigrationProgress).toHaveBeenCalledWith(
+          mockContext,
+          "react-upgrade",
+          "step1",
+          "skipped", 
+          {
+            prNumber: 123,
+            chunk: undefined,
+            reason: "PR closed without merging",
+          },
+          mockLogger
+        );
+
+        expect(mockOctokit.issues.createComment).toHaveBeenCalledWith(
+          expect.objectContaining({
+            body: expect.stringContaining("⚠️ **Step Skipped**: `step1`"),
+          })
+        );
+      });
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,8 +10,7 @@ export default defineConfig({
       "node_modules/**",
       "dist/**",
       "test/integration/**", // Temporarily disable integration tests
-      "test/unit/services/config.test.ts", // Temporarily disable while fixing
-      "test/unit/webhooks/push.test.ts", // Temporarily disable while fixing complex mocking
+      "test/unit/webhooks/push.test.ts", // Complex test needs fixing - TODO for future iteration
     ],
     coverage: {
       provider: "v8",
@@ -46,11 +45,12 @@ export default defineConfig({
       ],
       thresholds: {
         // Meaningful coverage thresholds focusing on testable business logic
-        // Current: 39.88% with high coverage in utils, config, and core services
-        statements: 39.8,
-        branches: 85,
-        functions: 75,
-        lines: 39.8,
+        // Current: 55.53% with comprehensive coverage in utils, config, services, and key webhooks
+        // Major achievements: Plans (75%), Issues (98%), Config (100%), PR webhook (94%)
+        statements: 55,
+        branches: 88,
+        functions: 84,
+        lines: 55,
       },
     },
     setupFiles: ["./test/setup.ts"],


### PR DESCRIPTION
- Add tests for plans service (parsing, validation, dependencies)
- Add tests for issues service (GitHub issue/PR creation)
- Fix config service tests
- Add pull request webhook tests
- Update coverage thresholds to 55%

Coverage: plans 0%→75%, issues 0%→98%, PR webhook 0%→94%
Tests: 183→213 (+30 test cases)