### PR TITLE
Fix all GitHub Actions workflows to use pnpm instead of npm

### DIFF
--- a/.github/workflows/control-plane.yml
+++ b/.github/workflows/control-plane.yml
@@ -39,12 +39,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
+          cache: "pnpm"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
       - name: Install dependencies
         run: |
-          npm ci
-          npm run build
+          pnpm install
+          pnpm build
 
       - name: Identify control-plane issue
         id: find-issue

--- a/.github/workflows/detect-migrations.yml
+++ b/.github/workflows/detect-migrations.yml
@@ -25,16 +25,21 @@ jobs:
         with:
           fetch-depth: 0 # Full history for comparison
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
+          cache: "pnpm"
 
       - name: Install dependencies
         run: |
-          npm ci
-          npm run build
+          pnpm install
+          pnpm build
 
       - name: Detect changed migrations
         id: changes


### PR DESCRIPTION
## Summary
Fixes build failures in GitHub Actions by updating all workflows to use pnpm instead of npm.

## Changes
- ✅ **control-plane.yml**: Fixed npm → pnpm 
- ✅ **detect-migrations.yml**: Fixed npm → pnpm
- 🔄 **Remaining**: Need to fix execute-migration.yml, dogfood.yml, hachiko-agent.yml

## Problem
Workflows were failing with: *Dependencies lock file is not found... Supported file patterns: package-lock.json*

This project uses pnpm (has pnpm-lock.yaml) but workflows were configured for npm.

## Test Plan
- [ ] Merge this PR
- [ ] Verify workflows run successfully 
- [ ] Complete remaining workflow fixes in follow-up

## Related
Fixes the GitHub Actions failure that blocked webhook testing in PR #23.