### PR TITLE
Fix pnpm setup order in control-plane workflow

### DIFF
--- a/.github/workflows/control-plane.yml
+++ b/.github/workflows/control-plane.yml
@@ -35,16 +35,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "pnpm"
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
Fixes workflow failure by reordering pnpm and Node.js setup steps.

## Issue
Control-plane workflow fails with 'Unable to locate executable file: pnpm' because pnpm setup runs after Node.js setup.

## Fix


## Test Plan
- [ ] Merge PR
- [ ] Verify control-plane workflow runs successfully