### PR TITLE
Fix missing actions permission in migration-dashboard workflow

### DIFF
--- a/.github/workflows/migration-dashboard.yml
+++ b/.github/workflows/migration-dashboard.yml
@@ -23,6 +23,7 @@ permissions:
   contents: write # To create PRs and update files
   issues: write # To update migration-dashboard issue
   pull-requests: write # To create and manage PRs
+  actions: write # To trigger workflow dispatches
 
 jobs:
   handle-migration-dashboard:


### PR DESCRIPTION
## Summary
- Add  permission to migration-dashboard workflow
- This fixes HTTP 403 error when trying to dispatch execute-migration.yml workflow

## Problem
The migration dashboard workflow was failing when trying to trigger migrations with:


## Solution
Added the missing  permission needed for  to dispatch workflows.

## Test Plan
- [x] Commit includes the permission fix
- [ ] Re-test migration trigger after merge
- [ ] Verify workflow dispatch succeeds