### PR TITLE
Fix migration dashboard workflow to preserve checkbox states

### DIFF
--- a/.github/workflows/migration-dashboard.yml
+++ b/.github/workflows/migration-dashboard.yml
@@ -99,6 +99,7 @@ jobs:
 
       - name: Handle issue edit
         if: github.event_name == 'issues' && github.event.issue.number == fromJson(steps.find-issue.outputs.migration_dashboard_issue)
+        id: handle-edit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
@@ -115,6 +116,7 @@ jobs:
           CHECKED_PAUSED=$(echo "$ISSUE_BODY" | awk '/## ⏸️ Paused Migrations/,/---/ { if (/^- \[x\]/) print }' | sed 's/^- \[x\] `//' | sed 's/`.*$//')
 
           # Process checked migrations
+          MIGRATIONS_TRIGGERED=false
           for MIGRATION_ID in $CHECKED_PENDING $CHECKED_PAUSED; do
             if [ -n "$MIGRATION_ID" ] && [ "$MIGRATION_ID" != "✨" ]; then
               echo "Starting migration: $MIGRATION_ID"
@@ -123,8 +125,13 @@ jobs:
               gh workflow run execute-migration.yml \
                 -f migration_id="$MIGRATION_ID" \
                 -f step_id="1"
+              
+              MIGRATIONS_TRIGGERED=true
             fi
           done
+          
+          # Set output for conditional issue update
+          echo "migrations_triggered=$MIGRATIONS_TRIGGERED" >> $GITHUB_OUTPUT
 
       - name: Handle PR closure
         if: github.event_name == 'pull_request' && github.event.pull_request.state == 'closed'
@@ -158,6 +165,7 @@ jobs:
           fi
 
       - name: Update migration-dashboard issue
+        if: steps.handle-edit.outputs.migrations_triggered != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ steps.find-issue.outputs.migration_dashboard_issue }}


### PR DESCRIPTION
## Summary
- Fix workflow that was resetting all checkboxes when updating the migration dashboard issue
- Add conditional logic to only regenerate issue when no migrations are triggered
- This enables the end-to-end migration workflow to function properly

## Problem
The migration dashboard workflow had a critical flaw:
1. User checks migration checkbox → Triggers workflow  
2. "Handle issue edit" step → Parses checkboxes and dispatches migrations
3. "Update migration-dashboard issue" step → **Always ran and regenerated issue from scratch**
4. Result: All checkboxes reset to unchecked, breaking the workflow

## Solution
- Add `migrations_triggered` output to track if any migrations were started
- Make issue update step conditional: `if: steps.handle-edit.outputs.migrations_triggered != 'true'`
- This preserves checkbox states when migrations are triggered
- Issue still gets updated for other events (PR closures, manual updates)

## Test Plan
- [x] Workflow logic updated with conditional step
- [ ] Test by checking migration checkbox after merge
- [ ] Verify migration dispatch succeeds and preserves checkbox state
- [ ] Confirm end-to-end flow works: checkbox → dispatch → PR creation → status update