### PR TITLE
Fix workflow shell syntax errors and add validation tests

### DIFF
--- a/.github/workflows/execute-migration.yml
+++ b/.github/workflows/execute-migration.yml
@@ -22,6 +22,7 @@ permissions:
   contents: write # To create PRs and update files
   issues: write # To update control-plane issue
   pull-requests: write # To create and manage PRs
+  actions: write # To trigger workflow dispatches
 
 jobs:
   execute-migration-step:
@@ -70,9 +71,9 @@ jobs:
           fi
 
           # Parse key fields (simplified YAML parsing)
-          TITLE=$(echo "$FRONTMATTER" | grep "^title:" | sed 's/title: *//' | tr -d '"'"'"' | tr -d '"')
-          AGENT=$(echo "$FRONTMATTER" | grep "^agent:" | sed 's/agent: *//' | tr -d '"'"'"' | tr -d '"')
-          STATUS=$(echo "$FRONTMATTER" | grep "^status:" | sed 's/status: *//' | tr -d '"'"'"' | tr -d '"')
+          TITLE=$(echo "$FRONTMATTER" | grep "^title:" | sed 's/title: *//' | tr -d "'" | tr -d '"')
+          AGENT=$(echo "$FRONTMATTER" | grep "^agent:" | sed 's/agent: *//' | tr -d "'" | tr -d '"')
+          STATUS=$(echo "$FRONTMATTER" | grep "^status:" | sed 's/status: *//' | tr -d "'" | tr -d '"')
           CURRENT_STEP=$(echo "$FRONTMATTER" | grep "^current_step:" | sed 's/current_step: *//')
           TOTAL_STEPS=$(echo "$FRONTMATTER" | grep "^total_steps:" | sed 's/total_steps: *//')
 

--- a/test/unit/github-workflows.test.ts
+++ b/test/unit/github-workflows.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
+import { spawn } from "child_process";
+import yaml from "js-yaml";
+
+/**
+ * Test suite to validate GitHub Actions workflow files for syntax errors
+ * This prevents shell script syntax errors from being committed to the repository
+ */
+describe("GitHub Workflows Validation", () => {
+  const workflowsDir = join(process.cwd(), ".github/workflows");
+  
+  // Get all YAML files in the workflows directory
+  const workflowFiles = readdirSync(workflowsDir).filter(file => 
+    file.endsWith('.yml') || file.endsWith('.yaml')
+  );
+
+  describe("YAML Syntax Validation", () => {
+    workflowFiles.forEach(filename => {
+      it(`should have valid YAML syntax: ${filename}`, () => {
+        const filepath = join(workflowsDir, filename);
+        const content = readFileSync(filepath, 'utf8');
+        
+        expect(() => {
+          yaml.load(content);
+        }).not.toThrow();
+      });
+    });
+  });
+
+  describe("Shell Script Syntax Validation", () => {
+    workflowFiles.forEach(filename => {
+      it(`should have valid shell script syntax in run blocks: ${filename}`, async () => {
+        const filepath = join(workflowsDir, filename);
+        const content = readFileSync(filepath, 'utf8');
+        
+        // Parse YAML to extract shell scripts
+        const workflow = yaml.load(content) as any;
+        const shellScripts = extractShellScripts(workflow);
+        
+        // Validate each shell script
+        const errors: string[] = [];
+        
+        for (const [location, script] of shellScripts) {
+          try {
+            await validateShellScript(script);
+          } catch (error) {
+            errors.push(`${location}: ${error}`);
+          }
+        }
+        
+        if (errors.length > 0) {
+          throw new Error(
+            `Shell script syntax errors in ${filename}:\n${errors.join('\n')}`
+          );
+        }
+      });
+    });
+  });
+});
+
+/**
+ * Recursively extract all shell scripts from a GitHub Actions workflow
+ */
+function extractShellScripts(obj: any, path: string = ""): Array<[string, string]> {
+  const scripts: Array<[string, string]> = [];
+  
+  if (!obj || typeof obj !== 'object') {
+    return scripts;
+  }
+  
+  // Check if this is a step with a run command
+  if (obj.run && typeof obj.run === 'string') {
+    const stepName = obj.name || 'unnamed step';
+    scripts.push([`${path}.${stepName}`, obj.run]);
+  }
+  
+  // Recursively search nested objects
+  for (const [key, value] of Object.entries(obj)) {
+    if (typeof value === 'object' && value !== null) {
+      const nestedPath = path ? `${path}.${key}` : key;
+      scripts.push(...extractShellScripts(value, nestedPath));
+    }
+  }
+  
+  return scripts;
+}
+
+/**
+ * Validate shell script syntax using bash -n (syntax check only, no execution)
+ */
+async function validateShellScript(script: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const bash = spawn('bash', ['-n'], {
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    
+    let stderr = '';
+    
+    bash.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+    
+    bash.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`Syntax error: ${stderr.trim()}`));
+      }
+    });
+    
+    bash.on('error', (error) => {
+      reject(new Error(`Failed to spawn bash: ${error.message}`));
+    });
+    
+    // Write the script to bash stdin
+    bash.stdin.write(script);
+    bash.stdin.end();
+  });
+}


### PR DESCRIPTION
## Summary

- Fix shell quote escaping syntax error in execute-migration.yml causing CI failures
- Add missing `actions: write` permission for workflow dispatch 
- Add comprehensive GitHub workflow validation test suite to prevent future syntax errors

## Root Cause

The CI failure was caused by malformed shell quote escaping syntax in execute-migration.yml:
```bash
# BROKEN (line 73-75)
tr -d '"'"'"'  # unexpected EOF while looking for matching quote

# FIXED  
tr -d "'" | tr -d '"'  # clean quote removal
```

Additionally, the execute-migration.yml workflow lacked `actions: write` permission needed to trigger the migration-dashboard workflow.

## Solution

1. **Fixed Shell Syntax**: Simplified complex quote escaping with safer approach
2. **Added Permission**: Added `actions: write` to execute-migration.yml permissions
3. **Added Prevention**: Created comprehensive test suite that validates all GitHub workflow shell scripts

## New Test Coverage

The new `test/unit/github-workflows.test.ts` provides:
- ✅ YAML syntax validation for all workflow files
- ✅ Shell script syntax validation using `bash -n` 
- ✅ Detailed error reporting with exact location
- ✅ Comprehensive coverage of all `.github/workflows/` files

## Test Results

- **Before Fix**: Test fails with exact same error as CI (`unexpected EOF while looking for matching quote`)
- **After Fix**: All 12 validation tests pass across 6 workflow files
- **Integration**: Runs seamlessly with existing test suite (`pnpm test`)

This ensures shell script syntax errors are caught during PR review, not during workflow execution.

## Fixes

Resolves the CI failures identified in:
- https://github.com/launchdarkly-labs/hachiko/actions/runs/21187595283/job/60946229073