### PR TITLE
Fix: Add hachiko:migration labels to automated PR creation

### DIFF
--- a/.github/workflows/detect-migrations.yml
+++ b/.github/workflows/detect-migrations.yml
@@ -206,6 +206,7 @@ jobs:
           # Create PR
           gh pr create \
             --title "📋 Enhanced Migration: $MIGRATION_ID" \
+            --label "hachiko:migration" \
             --body "$(cat <<'EOF'
           ## Migration Enhancement
 

--- a/.github/workflows/execute-migration.yml
+++ b/.github/workflows/execute-migration.yml
@@ -248,6 +248,7 @@ jobs:
           # Create pull request
           gh pr create \
             --title "🔄 Migration: $MIGRATION_TITLE (Step $STEP_ID/$TOTAL_STEPS)" \
+            --label "hachiko:migration" \
             --body "$(cat <<EOF
           ## Migration Progress: Step $STEP_ID/$TOTAL_STEPS
 
@@ -338,6 +339,7 @@ jobs:
           # Create PR for failure status update
           gh pr create \
             --title "❌ Migration failed: $MIGRATION_ID" \
+            --label "hachiko:migration" \
             --body "Migration execution failed and status has been updated.
 
           **Migration**: \`$MIGRATION_ID\`


### PR DESCRIPTION
## Problem

PRs created automatically by Hachiko workflows were missing the `hachiko:migration` label, making them harder to track and potentially causing issues with the migration state inference system.

## Solution

Added `--label "hachiko:migration"` flag to all `gh pr create` commands in:

- `.github/workflows/execute-migration.yml` (both success and failure cases)
- `.github/workflows/detect-migrations.yml`

## Testing

This change will be tested when the next migration runs and creates PRs automatically.

## Related

Fixes the issue mentioned in https://github.com/launchdarkly-labs/hachiko/pull/43 where PRs were missing the required label.