### PR TITLE
Fix: Migration dashboard updates for PR events

### DIFF
--- a/.github/workflows/migration-dashboard.yml
+++ b/.github/workflows/migration-dashboard.yml
@@ -5,7 +5,7 @@ on:
   issues:
     types: [edited]
   pull_request:
-    types: [closed]
+    types: [opened, synchronize, closed]
 
   # Allow manual trigger for testing
   workflow_dispatch:
@@ -133,6 +133,23 @@ jobs:
           # Set output for conditional issue update
           echo "migrations_triggered=$MIGRATIONS_TRIGGERED" >> $GITHUB_OUTPUT
 
+      - name: Handle PR opened/updated
+        if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "PR ${{ github.event.action }}: $PR_TITLE"
+          echo "Branch: $PR_BRANCH"
+
+          # Check if this is a Hachiko migration PR (by branch or label)
+          if [[ "$PR_BRANCH" == hachiko/* ]] || gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name' | grep -q "hachiko:migration"; then
+            echo "Hachiko migration PR detected - will update dashboard"
+          else
+            echo "Not a Hachiko migration PR - no dashboard update needed"
+          fi
+
       - name: Handle PR closure
         if: github.event_name == 'pull_request' && github.event.pull_request.state == 'closed'
         env:
@@ -165,7 +182,11 @@ jobs:
           fi
 
       - name: Update migration-dashboard issue
-        if: steps.handle-edit.outputs.migrations_triggered != 'true'
+        if: |
+          steps.handle-edit.outputs.migrations_triggered != 'true' &&
+          (github.event_name == 'pull_request' || 
+           github.event_name == 'workflow_dispatch' ||
+           (github.event_name == 'issues' && github.event.issue.number == fromJson(steps.find-issue.outputs.migration_dashboard_issue)))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ steps.find-issue.outputs.migration_dashboard_issue }}


### PR DESCRIPTION
## Problem

The migration dashboard issue (#29) was not updating when Hachiko PRs were created, only when they were closed. This caused the dashboard to show stale information about migration states.

## Root Cause

The `migration-dashboard.yml` workflow was only configured to trigger on:
- `pull_request: closed` (when PRs are closed)
- `issues: edited` (when the dashboard issue is edited)

It was **missing** triggers for when PRs are opened or updated.

## Solution

Updated `.github/workflows/migration-dashboard.yml`:

1. **Added missing PR triggers**:
   

2. **Added handler for PR opened/updated events**:
   - Detects Hachiko migration PRs by branch name (`hachiko/*`) or label (`hachiko:migration`)
   - Logs when a Hachiko migration PR is detected

3. **Updated dashboard update condition**:
   - Now updates the dashboard for **all** PR events (opened, synchronize, closed)
   - Ensures the migration state is refreshed whenever PR state changes

## Expected Behavior

When a Hachiko PR is created (like #43):
1. The workflow will trigger on `pull_request: opened`
2. It will detect the Hachiko migration PR
3. It will update issue #29 with the current migration state

## Testing

This will be tested when the next Hachiko PR is created or when existing ones are updated.

## Related

- Fixes https://github.com/launchdarkly-labs/hachiko/issues/29 not updating when PRs are created
- Complements the label fixes from PR #44