### PR TITLE
Monorepo structure step 1

### DIFF
--- a/migrations/flatten-monorepo.md
+++ b/migrations/flatten-monorepo.md
@@ -22,9 +22,9 @@ The current monorepo structure with `packages/app/` and `packages/runner-scripts
 
 ### Step 1: Move source files
 
-- Move `packages/app/src/*` to `src/`
-- Move `packages/app/test/*` to `test/`
-- Move `packages/app/dist/*` to `dist/`
+- [x] Move `packages/app/src/*` to `src/`
+- [x] Move `packages/app/test/*` to `test/`
+- [x] Move `packages/app/dist/*` to `dist/`
 
 ### Step 2: Update package.json
 
@@ -55,3 +55,8 @@ The current monorepo structure with `packages/app/` and `packages/runner-scripts
 - Potential import path breakage
 - CI/CD workflow adjustments needed
 - Documentation updates required
+
+## Critical Learnings
+
+- Repository layout already matches Step 1 outcomes (`src/`, `test/`, and `dist/` at root, with no `packages/` directory present).
+- `pnpm-lock.yaml` still includes historical `packages/app` and `packages/runner-scripts` entries that can be validated/cleaned when package/workspace changes are finalized in later steps.


### PR DESCRIPTION
Update the `flatten-monorepo` migration document to mark Step 1 complete and add learnings, as the required file moves were already implemented.

The code changes for Step 1 (moving `src`, `test`, `dist` from `packages/app` to the repository root) were found to be already present in the codebase. This PR updates the migration document to reflect this completion and document the discovery.

---
<p><a href="https://cursor.com/agents/bc-23a01697-7156-483b-89f9-2a3f8fd0a017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23a01697-7156-483b-89f9-2a3f8fd0a017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

